### PR TITLE
Add Message Resource explainer

### DIFF
--- a/explainers/message-resource.abnf
+++ b/explainers/message-resource.abnf
@@ -1,0 +1,87 @@
+; A resource consists of any number of
+; section headers, entries, comments and empty lines.
+; These are all separated from each other by LF or CRLF line endings.
+; Except for empty lines, all lines start with a non-whitespace character.
+resource = line *(newline line)
+line = frontmatter / section-head / entry / metadata / comment / empty-line
+
+; Comments and metadata before the frontmatter attach to the entire resource.
+; A valid resource must have at most one frontmatter,
+; and it must not have any section-head or entry lines before the frontmatter.
+frontmatter = "---" [ws]
+
+; As in TOML, entries after a section-head belong to the section.
+; Sections do not nest under preceding sections,
+; but must always define their full id path.
+section-head = "[" [ws] id [ws] "]" [ws]
+entry = id [ws] "=" [ws] value
+
+; Metadata attaches properties to the subsequent frontmatter, section-head or entry.
+; Other metadata lines are valid between metadata and its target,
+; but comments and empty lines are not.
+; As with entries, the value of metadata may span multiple lines,
+; provided that each beyond the first is indented by some whitespace.
+metadata = "@" id-part [ws value]
+
+; Adjacent comments should be considered as a single multi-line comment.
+; Comments attach to a subsequent frontmatter, section-head or entry,
+; if not separated from it by any empty lines.
+; Metadata lines are valid between comments and their target.
+comment = "#" *(content / backslash)
+empty-line = [ws]
+
+ws = 1*(SP / HTAB)
+newline = CRLF / LF
+
+; An identifier is made up of one or more non-empty parts separated by dots.
+; Common symbols and non-printable characters must be \escaped in identifiers.
+; To avoid conflicts with frontmatter, and id starting with `---`
+; or consisting only of `-` characters must `\-` escape at least one of them.
+id = id-start *([ws] "." [ws] id-part)
+id-start = (["-"] ["-"] id-char [id-part]) / ("-" ["-"])
+id-part = 1*(id-char / "-")
+id-char = id-safe / id-escape
+id-safe = ALPHA / DIGIT / "_"
+        / %x00A1-1FFF / %x200C-200D / %x2030-205E / %x2070-2FEF
+        / %x3001-D7FF / %xF900-FDCF / %xFDF0-FFFD / %x10000-EFFFF
+id-escape = backslash (escaped / symbols)
+symbols = %x21-2F / %x3A-40 / %x5B-60 / %x7B-7E ; ASCII symbols and punctuation
+        / %xA1-BF / %xD7 / %xF7 ; Latin-1 symbols and punctuation
+        / %x2010-2027 / %x2030-205E / %x2190-2BFF ; General symbols and punctuation
+
+; Values must be parsed as MF2 messages.
+; A message may be defined on multiple lines,
+; as long as each line after the first is indented by at least one space.
+; If a message body line starts with significant whitespace,
+; its first character must be \escaped.
+; When a newline occurs in a value,
+; it is always considered to represent a single U+000A LF character.
+; To include a U+000D CR character in a value, it must be \r escaped.
+value = value-line *(newline ws value-line)
+value-line = [(value-start / value-escape) *(content / value-escape)]
+; A resource must not contain any control characters or vertical whitespace
+; which might be mistaken for newlines.
+value-start = %x21-5B ; omit C0 controls, SP, and \
+            / %x5D-7E ; omit C1 controls
+            / %x00A0-2027 ; omit LSEP & PSEP
+            / %x202A-D7FF ; omit surrogates
+            / %xE000-10FFFF
+content = SP / HTAB / value-start
+; Each of the escape sequences recognised by MF2 \\, \{, \|, \}
+; pass through resource parsing as complete and intact,
+; so that they do not need to be double-escaped.
+value-escape = backslash (escaped / "{" / "|" / "}")
+
+; The bulk of valid escapes is shared between id-escape and value-escape.
+; If a newline is \ escaped, it (and the subsequent whitespace indentation) is ignored.
+; This allows for long keys and values to be wrapped for legibility.
+; As an example, each of the these is a valid representation of a horizontal tab:
+; \	, \t, \x09, \u0009, \U000009
+escaped = backslash
+        / (newline ws)
+        / SP / HTAB
+        / %s"n" / %s"r" / %s"t" ; represent LF, CR, HTAB
+        / (%s"x" HEXDIG HEXDIG)
+        / (%s"u" HEXDIG HEXDIG HEXDIG HEXDIG)
+        / (%s"U" HEXDIG HEXDIG HEXDIG HEXDIG HEXDIG HEXDIG)
+backslash = "\"

--- a/explainers/message-resource.d.ts
+++ b/explainers/message-resource.d.ts
@@ -1,0 +1,166 @@
+/**
+ * The data model representation of a message resource.
+ *
+ * This is not a CST, so does not encode whitespace or empty lines.
+ * Users are encouraged to not consider them significant,
+ * and to always normalize the syntax representation of a resource
+ * when manipulating it programmatically.
+ *
+ * Similarly, all character escapes are processed in this representation
+ * (for all identifiers, metadata, and for `string` entry values),
+ * and users are encouraged to always normalize
+ * the syntax representation of escaped characters.
+ */
+export interface Resource<Message> {
+  /**
+   * A comment on the whole resource, which applies to all of its sections and entries.
+   *
+   * May contain multiple lines separated by `\n` characters.
+   * For each line, the `#` sigil and up to one space or tab is trimmed
+   * from the start of the line, along with any trailing whitespace.
+   * In the syntax, each line will be prefixed by `#` and if the line is not empty, one space.
+   *
+   * An empty or whitespace-only comment will be represented by an empty string.
+   *
+   * In the syntax, resource comments are separated from the rest of the resource
+   * by a frontmatter separator line `---`.
+   */
+  comment: string;
+
+  /**
+   * Metadata attached to the whole resource.
+   *
+   * In the syntax, these are separated from the rest of the resource
+   * by a frontmatter separator line `---`.
+   */
+  meta: Metadata[];
+
+  /**
+   * The body of a resource, consisting of an array of sections.
+   *
+   * A valid resource may have an empty sections array.
+   */
+  sections: Section<Message>[];
+}
+
+/**
+ * Metadata is attached to a resource, section, or a single entry.
+ */
+export interface Metadata {
+  /**
+   * A non-empty string keyword.
+   *
+   * Most likely a sequence of `a-z` characters,
+   * but may technically contain _any_ characters
+   * which might require escaping in the syntax.
+   */
+  key: string;
+
+  /**
+   * The metadata contents.
+   *
+   * Values have all their character \escapes processed.
+   * Note that the processed values of `\\`, `\{`, `\|`, and `\}`
+   * are exactly the same characters sequences.
+   */
+  value: string;
+}
+
+export interface Section<Message> {
+  /**
+   * A comment on the whole section, which applies to all of its entries.
+   *
+   * May contain multiple lines separated by `\n` characters.
+   * For each line, the `#` sigil and up to one space or tab is trimmed
+   * from the start of the line, along with any trailing whitespace.
+   * In the syntax, each line will be prefixed by `#` and if the line is not empty, one space.
+   *
+   * An empty or whitespace-only comment will be represented by an empty string.
+   * */
+  comment: string;
+
+  /** Metadata attached to this section. */
+  meta: Metadata[];
+
+  /**
+   * The section identifier.
+   *
+   * Each `string` part of the identifier MUST be a non-empty string.
+   *
+   * The top-level or anonymous section has an empty `id` array.
+   * The resource syntax requires this array to be non-empty
+   * for all sections after the first one,
+   * but empty identifier arrays MAY be used
+   * when this data model is used to represent other message resource formats,
+   * such as Fluent FTL files.
+   *
+   * The entry identifiers are not normalized,
+   * i.e. they do not include this identifier.
+   */
+  id: string[];
+
+  /**
+   * Section entries consist of message entries and comments,
+   * each identified by its string `type` property.
+   *
+   * Empty lines are not included in the data model.
+   */
+  entries: (Entry<Message> | Comment)[];
+}
+
+export interface Entry<Message> {
+  type: "entry";
+
+  /**
+   * A comment on this entry.
+   *
+   * May contain multiple lines separated by `\n` characters.
+   * For each line, the `#` sigil and up to one space or tab is trimmed
+   * from the start of the line, along with any trailing whitespace.
+   * In the syntax, each line will be prefixed by `#` and if the line is not empty, one space.
+   *
+   * An empty or whitespace-only comment will be represented by an empty string.
+   * */
+  comment: string;
+
+  /** Metadata attached to this entry. */
+  meta: Metadata[];
+
+  /**
+   * The entry identifier.
+   *
+   * This MUST be a non-empty array of non-empty `string` values.
+   *
+   * The identifiers of entries in a section are not normalized,
+   * i.e. they do not include its identifier.
+   *
+   * In a valid resource, each entry has a distinct normalized identifier,
+   * i.e. the concatenation of its section header identifier (if any) and its own.
+   */
+  id: string[];
+
+  /**
+   * The value of an entry, i.e. the message.
+   *
+   * String values have all their character \escapes processed.
+   * Note that the processed values of `\\`, `\{`, `\|`, and `\}`
+   * are exactly the same characters sequences.
+   */
+  value: Message;
+}
+
+export interface Comment {
+  type: "comment";
+
+  /**
+   * A standalone comment.
+   *
+   * May contain multiple lines separated by `\n` characters.
+   * For each line, the `#` sigil and up to one space or tab is trimmed
+   * from the start of the line, along with any trailing whitespace.
+   * In the syntax, each line will be prefixed by `#` and if the line is not empty, one space.
+   *
+   * An empty or whitespace-only comment will be represented by an empty string.
+   * */
+  comment: string;
+}

--- a/explainers/message-resource.json
+++ b/explainers/message-resource.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://w3c.github.io/i18n-discuss/explainers/message-resource.json",
+
+  "type": "object",
+  "properties": {
+    "comment": { "type": "string" },
+    "meta": { "$ref": "#/$defs/meta" },
+    "sections": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "comment": { "type": "string" },
+          "id": { "$ref": "#/$defs/id" },
+          "meta": { "$ref": "#/$defs/meta" },
+          "entries": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                { "$ref": "#/$defs/comment" },
+                { "$ref": "#/$defs/entry" }
+              ]
+            }
+          }
+        },
+        "required": ["entries"]
+      }
+    }
+  },
+  "required": ["sections"],
+
+  "$defs": {
+    "comment": {
+      "type": "object",
+      "properties": {
+        "type": { "const": "comment" },
+        "comment": { "type": "string" }
+      },
+      "required": ["type", "comment"]
+    },
+    "entry": {
+      "type": "object",
+      "properties": {
+        "type": { "const": "entry" },
+        "comment": { "type": "string" },
+        "id": { "$ref": "#/$defs/id" },
+        "meta": { "$ref": "#/$defs/meta" },
+        "value": {
+          "$ref": "https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model/message.json"
+        }
+      },
+      "required": ["type", "id", "value"]
+    },
+    "id": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "meta": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "$ref": "#/$defs/id" },
+          "value": { "type": "string" }
+        },
+        "required": ["id", "value"]
+      }
+    }
+  }
+}

--- a/explainers/message-resources.md
+++ b/explainers/message-resources.md
@@ -1,0 +1,206 @@
+# Explainer: Message Resources
+
+The purpose of this effort is to develop the specification
+for a **_message resource_** as a standard container for [Unicode MessageFormat] ("MF2") messages.
+The serialized form of a message resource may be used as a file format.
+
+[unicode messageformat]: https://github.com/unicode-org/message-format-wg
+
+In this context, a "resource" is a collection of related messages
+that may need to be stored, transmitted and/or handled together.
+A resource may classify its messages into groupings,
+and it may include additional data or metadata relating to them.
+It should be possible to represent a resource in a text-based human-friendly manner.
+
+This work has been [presented](https://www.youtube.com/watch?v=ksgm_B-uUCU)
+at the [2024 Unicode Tech Workshop](https://www.unicode.org/events/utw/2024/),
+and accepted for incubation by the W3C Internationalization WG at TPAC 2025.
+
+Message resources are a prerequisite for [DOM Localization].
+
+[dom localization]: https://github.com/mozilla/explainers/blob/main/dom-localization.md
+
+### Why?
+
+The prior work on a new message format has identified the following challenges
+that go beyond or arise from defining the syntax and behavior of a single message,
+but which are not well addressed by existing resource formats:
+
+- The Unicode MessageFormat message syntax is naturally multi-line due to its internal structure,
+  and multi-line values are not easy to use in many of the current resource formats.
+- Comments and metadata (set either by automation or manually)
+  are an important means for translators and developers to communicate with one-another,
+  but are irrelevant to the retrieval and display of the message.
+  Their attachment to messages needs to be well specified,
+  while being easy to read, write, and ignore.
+- Structured metadata needs a common schema in order to be universally understood.
+- Hierarchical groupings of messages need to be representable,
+  and metadata be assignable not only to individual messages,
+  but also groups of messages.
+- Many localizable messages need to be composed together
+  (such as an HTML element with a localizable body and localizable attributes),
+  and it should be possible to express a compound message formed of multiple connected parts.
+  While Unicode MessageFormat does support e.g. markup elements with option values,
+  this may make it difficult to segment a message's localizable parts from each other.
+- A purpose-built localization resource format should be well specified,
+  and designed from the ground up to work with multiple implementations.
+  Its design and capabilities need to account for existing localization formats,
+  and allow for the representation of messages and resources in those formats.
+
+Some of these aspects are well supported by existing formats,
+but no one resource format serves all of the identified use cases.
+For instance:
+
+- Comments in Gettext .po files come in multiple types and each [clearly attaches] to the following entry,
+  but the format's representation of multi-line values is rather clumsy.
+- Fluent supports composability via [attributes] and [message references],
+  but its FTL format is tightly coupled with its own message format.
+- XLIFF is an [OASIS Standard],
+  but it is primarily a machine interchange format that is not designed for human authoring
+  and its message representation does not provide for message variants.
+
+It would of course be possible to define a JSON or XML Schema
+for a resource format that would address all of the above issues.
+However, while JSON and XML are relatively easy to read, they are not easy to _write_.
+This is a disadvantage to users, such as developers or translators,
+who expect to use existing editors, especially simple text editors,
+to create and manage these files.
+JSON/XML schemas should be defined as a part of the effort,
+to represent a data model view of the resource formats,
+complementing the [message data model].
+
+[clearly attaches]: https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html
+[attributes]: https://projectfluent.org/fluent/guide/attributes.html
+[message references]: https://projectfluent.org/fluent/guide/references.html
+[message data model]: https://github.com/unicode-org/message-format-wg/tree/main/spec/data-model
+[OASIS Standard]: https://docs.oasis-open.org/xliff/xliff-core/v2.1/os/xliff-core-v2.1-os.html
+
+### Paths to Adoption
+
+The field of localization is not new, and already features many competing solutions,
+with workflows, tools and practices used by many different projects,
+each of which have different needs.
+In this environment, a new solution should not aim to replace all parts at once,
+but to provide a modular, layered approach that users could benefit from
+without needing to adopt all parts of the new standard.
+
+This approach is already fundamental to the Unicode MessageFormat specification,
+which is designed to be embeddable in any existing resource formats.
+The resource format work should follow a similar approach,
+for example by ensuring that its data model provides not only a useful representation
+of any syntax representation of a resource format defined here,
+but also all existing resource formats.
+Doing so makes it much easier for resource format conversion tools to be built,
+not only to and from the new format, but also between existing formats.
+
+Similarly, a well-defined set of message properties or metadata
+could be adopted completely separately from the rest of the specification.
+It could be defined within the context of the new resource format,
+or as a separate action by the [Unicode MessageFormat WG][unicode messageformat].
+
+### Non-Goals
+
+At least initially, the work should focus on the definition of
+the data held within a localization resource, including its data model representation,
+but not on how that data is to be processed.
+In other words, a message resource specification should not mandate
+the runtime behaviour of a message formatter or other tool processing said data.
+
+The following are therefore explicitly left out of scope:
+
+- Whether and how multiple resources could be bundled together at runtime.
+- Whether and how to perform fallback between locales if a resource is incomplete for a first-choice locale.
+- Whether and how to query and iterate messages within a resource.
+
+The adoption and usage of message resources for [DOM Localization]
+is expected to answer many of these questions in the context of their use on the web.
+
+## Proposed Solution
+
+Within the overall purpose of defining a new resource format,
+the work can be split into the following parts:
+
+1. Defining the resource syntax.
+2. Defining the data model representation of a resource.
+3. Defining or adopting a vocabulary for message and resource properties/metadata.
+
+While the primary driver for the work is to support Unicode MessageFormat,
+other current and future localization formats also need to be considered.
+For example, it should be possible to:
+
+- represent a Gettext `.po` file using the data model,
+- use the same message properties within some other custom resource format, and
+- embed messages with a different format than MF2 in a message resource.
+
+The definition of a resource loader is not within the scope of this work,
+except insofar as its concerns impact the deliverables enumerated above.
+
+The definition of message and resource properties is currently
+[under consideration](https://github.com/unicode-org/message-format-wg/pull/1098)
+as a work item of the Unicode MessageFormat WG,
+and hence is not included here.
+
+### Syntax
+
+As currently proposed,
+a message resource looks like this
+(syntax highlighting only approximate):
+
+```ini
+# The resource-level locale is the only required property.
+@locale en-US
+---
+
+one = A plain, simple message.
+
+@param $placeholder - A comment on the placeholder value.
+two = Another message with a {$placeholder}.
+
+@param $foobar - An input parameter
+                 with a multiline description
+three = Some {$foobar} message
+  with a multiline value
+  \  and a third line that starts with two spaces.
+
+[section]
+
+four =
+  .input {$count :integer}
+  .match $count
+  0   {{You have no messages.}}
+  one {{You have {$count} message.}}
+  *   {{You have {$count} messages.}}
+
+@do-not-translate
+[section.more]
+
+# This message (section.more.five) should not be modified from the original.
+five = Foo
+```
+
+This represents five `en-US` messages with keys `one`, `two`, `three`, `section.four`, and `section.more.five`.
+The comments and `@properties` each attach to the next
+section header, message entry, or resource frontmatter separator (not separated by whitespace).
+Properties and message values may be multiline, provided that each of the following lines is indented by some whitespace.
+All leading whitespace is trimmed from each line, unless it's escaped with `\`.
+
+The exact syntax for properties and
+[message values](https://github.com/unicode-org/message-format-wg/blob/main/spec/syntax.md)
+is defined separately.
+The canonical definition of the resource syntax is found in [`message-resource.abnf`](./message-resource.abnf).
+
+### Data Model
+
+A message resource data model corresponding to the syntax definition
+is included as [`message-resource.d.ts`](./message-resource.d.ts),
+an extensively commented TypeScript definition.
+
+To enable interchange, a JSON Schema definition of the data model
+is also provided in [`message-resource.json`](./message-resource.json).
+This corresponds to `Resource<Message>`
+in the parametric TypeScript definition,
+where `Message` is a [Unicode MessageFormat Message](https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model/README.md#messages).
+
+As with the Unicode MessageFormat data model,
+the message resource JSON Schema relaxes some aspects of the data model,
+allowing comment and metadata values to be optional rather than required properties.


### PR DESCRIPTION
As discussed during TPAC; ping @aphillips and @xfq for review.

This has been adopted from content previously hosted under https://github.com/eemeli/message-resource-wg.