### PR TITLE
Try to fix Liquid parse error

### DIFF
--- a/explainers/message-resources.md
+++ b/explainers/message-resources.md
@@ -146,6 +146,8 @@ As currently proposed,
 a message resource looks like this
 (syntax highlighting only approximate):
 
+<!-- {% raw %} -->
+
 ```ini
 # The resource-level locale is the only required property.
 @locale en-US
@@ -177,6 +179,8 @@ four =
 # This message (section.more.five) should not be modified from the original.
 five = Foo
 ```
+
+<!-- {% endraw %} -->
 
 This represents five `en-US` messages with keys `one`, `two`, `three`, `section.four`, and `section.more.five`.
 The comments and `@properties` each attach to the next


### PR DESCRIPTION
The `{{` in the MF2 example [appears](https://github.com/w3c/i18n-discuss/actions/runs/19347776894/job/55352396108#step:4:13) to be getting picked up as a Liquid variable definition that's running as a part of the Jekyll build; I _think_ adding the [raw/endraw](https://shopify.github.io/liquid/tags/template/#raw) block should help with that, and the HTML comments wrapping those ought to mean that it won't affect GitHub's direct rendering of the markdown either.